### PR TITLE
The order of CR-LF characters is incorrect

### DIFF
--- a/src/hello.c
+++ b/src/hello.c
@@ -39,8 +39,8 @@ void putchar(char c)
 void puts(char *p)
 {
   while(*p) putchar(*p++);
-  putchar('\n');
   putchar('\r');
+  putchar('\n');
 }
 
 void main(void)

--- a/src/hello.s
+++ b/src/hello.s
@@ -46,9 +46,9 @@ puts:
 	lw	a5,-20(s0)
 	lbu	a5,0(a5)
 	bnez	a5,.L5
-	li	a0,10
-	call	putchar
 	li	a0,13
+	call	putchar
+	li	a0,10
 	call	putchar
 	nop
 	lw	ra,28(sp)


### PR DESCRIPTION
In the hello.c and hello.s files the LF (`'\n'`/10) is printed before CR (`'\r'`/13) which is incorrect. The correct sequence is CR-LF (`"\r\n"`)

I'm suggesting to fix those files as below. Or if the terminal is a Unix one then you don't need CR