### PR TITLE
Makefile convenience fixes and an utility to create a backtrace

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -35,6 +35,9 @@ INCS = ../rtl/config.vh
 XSIM = darksocv
 VCDS = darksocv.vcd
 
+.PRECIOUS: $(VCDS)	# Do not delete the trace file if simulation is aborted
+.PHONY: $(VCDS)		# Always run the simulation
+
 ifdef HARVARD
 	SRCS = ../src/darksocv.rom.mem ../src/darksocv.ram.mem
 else

--- a/sim/trace.py
+++ b/sim/trace.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from vcdvcd import VCDVCD
+
+import subprocess
+import sys
+import getopt
+
+class Error(Exception):
+    """addr2line exception."""
+
+    def __init__(self, str):
+        Exception.__init__(self, str)
+
+class addr2line:
+    def __init__(self, binary, addr2line = "/opt/riscv32e/bin/riscv32-unknown-elf-addr2line"):
+        self.process = subprocess.Popen(
+            [addr2line, "-e", binary],
+            stdin = subprocess.PIPE,
+            stdout = subprocess.PIPE)
+
+    def lookup(self, addr):
+        dbg_info = None
+        try:
+            self.process.stdin.write((addr + "\n").encode('utf-8'))
+            self.process.stdin.flush()
+            dbg_info = self.process.stdout.readline().decode("utf-8") 
+            dbg_info = dbg_info.rstrip("\n")
+        except IOError:
+            raise Error(
+                "Communication error with addr2line.")
+        finally:
+            ret = self.process.poll();
+            if ret != None:
+                raise Error(
+                    "addr2line terminated unexpectedly (%i)." % (ret))
+            
+        return dbg_info
+
+# Do the parsing.
+vcd = VCDVCD('darksocv.vcd')
+
+# Get a signal by human readable name.
+signal = vcd['darksimv.darksocv.core0.PC[31:0]']
+
+tv = signal.tv
+
+cache = {}
+a2l = addr2line("../src/darksocv.o")
+
+for x in tv:
+    time = x[0]
+    if 'x' in x[1]:
+        pc = x[1]
+        line = "undef"
+    else:
+        pc = hex(int(str(x[1]), 2))     # get a hex string out of pc
+        if pc in cache:
+            line = cache[pc]
+        else:
+            line = a2l.lookup(pc)
+            cache[pc] = line
+
+    print( f'{time:>12}' + ":" + f'{pc:>10}' + ":" + line)
+
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 
+SHELL := /bin/bash
+
 ifndef HOST_CC
     HOST_CC = gcc
     HOST_CFLAGS = -Wall -Wno-incompatible-library-redeclaration -I./include -Os


### PR DESCRIPTION
Hi Marcelo,

I've been hacking on and off the past few days, trying to run some code of mine on darksocv. The following changes could potentially benefit the project:

- Keep the VCD file even if simulation is aborted. Otherwise Make deletes it on failure
- Make sure that a trace(VCD) file is always generated, even if none of its dependencies have changed. Useful if e.g. you did a short simulation run and then want to do a longer one or vice versa
- Force usage of Bash by make. Without it, depending on the system shell, the {} expansion in  `-rm $(OBJS) $(PROJ).{bin,lst,map,ram,rom,x86,text,data,bin,ld,o}` may fail and some artifacts remain after `make clean`
- A small python script that reads the VCD file, extracts the program counter and tries to lookup the source code line that this PC value corresponds to. Result is a rough trace of program execution, like so:

>           0:         x:undef
>       25000:       0x0:/mnt/c/Work/darkriscv/src/boot.s:46
>     2465000:       0x4:/mnt/c/Work/darkriscv/src/boot.s:46
>     2475000:       0x8:/mnt/c/Work/darkriscv/src/boot.s:47
>     2495000:       0xc:/mnt/c/Work/darkriscv/src/boot.s:48
>     2505000:      0x10:/mnt/c/Work/darkriscv/src/boot.s:49
>     2515000:      0x14:/mnt/c/Work/darkriscv/src/boot.s:50
>     2525000:      0x18:/mnt/c/Work/darkriscv/src/boot.s:50
>     2535000:      0x1c:/mnt/c/Work/darkriscv/src/boot.s:51
>     2545000:      0x20:/mnt/c/Work/darkriscv/src/boot.s:65
>     2555000:      0x24:/mnt/c/Work/darkriscv/src/boot.s:65
>     2565000:      0x28:/mnt/c/Work/darkriscv/src/boot.s:66
>     2575000:      0x2c:/mnt/c/Work/darkriscv/src/boot.s:66
>     2585000:      0x30:/mnt/c/Work/darkriscv/src/boot.s:68
>     2595000:      0x34:/mnt/c/Work/darkriscv/src/boot.s:68
>     2605000:      0x38:/mnt/c/Work/darkriscv/src/boot.s:70
>     2615000:    0x1138:/mnt/c/Work/darkriscv/src/banner.c:36
>     2625000:    0x113c:/mnt/c/Work/darkriscv/src/banner.c:36
>     2635000:    0x1140:/mnt/c/Work/darkriscv/src/banner.c:36
>     2645000:    0x1144:/mnt/c/Work/darkriscv/src/banner.c:36
>     2655000:    0x1148:/mnt/c/Work/darkriscv/src/banner.c:93
>     2665000:    0x114c:/mnt/c/Work/darkriscv/src/banner.c:93
>     2675000:    0x1150:/mnt/c/Work/darkriscv/src/banner.c:93
>     2685000:    0x1154:/mnt/c/Work/darkriscv/src/banner.c:93
>     2695000:    0x1158:/mnt/c/Work/darkriscv/src/banner.c:93
>     2715000:    0x115c:/mnt/c/Work/darkriscv/src/banner.c:93
