### PR TITLE
Do not duplicate cache signals in Harvard mode

### DIFF
--- a/rtl/darkbridge.v
+++ b/rtl/darkbridge.v
@@ -125,10 +125,12 @@ module darkbridge
 
     // instruction cache
 
+`ifndef __HARVARD__
     wire         YDREQ;
     wire  [31:0] YADDR;
     wire  [31:0] YDATA;
     wire         YDACK;
+`endif
 
 `ifdef __ICACHE__
   


### PR DESCRIPTION
I had to use this trivial change, in order to have the default `make` command to work.
Here is the original error:
```
../rtl/darkbridge.v:128: error: 'YDREQ' has already been declared in this scope.
../rtl/darkbridge.v:56:      : It was declared here as a net.
...
```
With this fix, the build and test both work fine.