### PR TITLE
Fix rv32e mem build with recent gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ endif
 
 ifndef CROSS
 
-    export ARCH = rv32e
+    export ARCH = rv32e_zicsr
     #ARCH = rv32i
     
     export ABI = ilp32e


### PR DESCRIPTION
It seems like with recent gcc (15.0+ ?), rebuilding the rv32e memory generates `zicsr` instructions:
```
/usr/local/share/gcc-riscv32-embedded-elf/bin//riscv32-embedded-elf-as -march=rv32e -c boot.s -o boot.o
boot.s: Assembler messages:
boot.s:48: Error: unrecognized opcode `csrr a0,mhartid', extension `zicsr' required
```
This trivial patch changes the default build arch to include the `zicsr` extension.
Note that your rv32e toolchain should be configured like this:
`--with-arch=rv32e_zicsr --with-abi=ilp32e`
Then we are rebuild the `darksocv.mem` again, eg: with this gcc:
```
Using built-in specs.
COLLECT_GCC=./gcc-riscv32-embedded-elf/bin/riscv32-embedded-elf-gcc
COLLECT_LTO_WRAPPER=/tmp/gcc-riscv32-embedded-elf/libexec/gcc/riscv32-embedded-elf/15.0.0/lto-wrapper
Target: riscv32-embedded-elf
Configured with: ../configure --target=riscv32-embedded-elf --enable-languages=c --disable-shared --disable-threads --disable-multilib --disable-gdb --disable-libssp --with-newlib --with-arch=rv32e_zicsr --with-abi=ilp32e --prefix=/usr/local/share/gcc-riscv32-embedded-elf/bin
Thread model: single
Supported LTO compression algorithms: zlib
gcc version 15.0.0 20250107 (experimental) (GCC)
```