### PR TITLE
Fix src build

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -61,7 +61,7 @@ all: $(VCDS)
 	@echo simulation ok.
 
 clean:
-	-rm $(VCDS) $(XSIM) $(TRCE)
+	-rm -f $(VCDS) $(XSIM) $(TRCE)
 
 $(VCDS): $(XSIM)
 	@echo finish |                                          \

--- a/src/Makefile
+++ b/src/Makefile
@@ -81,7 +81,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(CC) $(CFLAGS) -S $< -o $@
 
 $(PROJ).ld: $(PROJ).lds Makefile
 	$(CPP) $(CPFLAGS) -DMLEN=$$(awk '/define MLEN/ { print 2**$$3 }' ../rtl/config.vh) $(PROJ).lds $(PROJ).ld

--- a/src/badapple/Makefile
+++ b/src/badapple/Makefile
@@ -50,7 +50,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(CC) $(CFLAGS) -S $< -o $@
 
 $(PROJ).a: $(OBJS) Makefile
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/src/config.mk
+++ b/src/config.mk
@@ -44,16 +44,16 @@ ifndef CROSS
     export ENDIAN = little
     #export ENDIAN = big
 
-    export CROSS = riscv64-unknown-elf-
-    #export CROSS = riscv32-unknown-elf-
-    #export CROSS = riscv32-embedded$(ENDIAN)-elf-
-    #export CROSS = riscv-elf-
-    #export CROSS = riscv32-unknown-elf-
-    #export CROSS = riscv32-embedded-elf-
+    #export CROSS = riscv64-unknown-elf
+    #export CROSS = riscv32-unknown-elf
+    #export CROSS = riscv32-embedded$(ENDIAN)-elf
+    #export CROSS = riscv-elf
+    #export CROSS = riscv32-unknown-elf
+    export CROSS = riscv32-embedded-elf
     
-    export CCPATH = /usr/local/bin
+    #export CCPATH = /usr/local/bin
     #export CCPATH = /opt/riscv/bin
-    #export CCPATH = /usr/local/share/gcc-$(CROSS)/bin/
+    export CCPATH = /usr/local/share/gcc-$(CROSS)/bin
     #export CCPATH = /usr/local/share/toolchain-$(CROSS)/bin
 endif
 
@@ -65,19 +65,19 @@ ifndef DARKLIBC
     export DARKLIBC = darklibc
 endif
 
-    export CC  = $(CCPATH)/$(CROSS)gcc
-    export AS  = $(CCPATH)/$(CROSS)as
-    export RL  = $(CCPATH)/$(CROSS)ranlib
-    export LD  = $(CCPATH)/$(CROSS)ld
-    export OC  = $(CCPATH)/$(CROSS)objcopy
-    export OD  = $(CCPATH)/$(CROSS)objdump
-    export AR  = $(CCPATH)/$(CROSS)ar
-    export CPP = $(CCPATH)/$(CROSS)cpp
+    export CC  = $(CCPATH)/$(CROSS)-gcc
+    export AS  = $(CCPATH)/$(CROSS)-as
+    export RL  = $(CCPATH)/$(CROSS)-ranlib
+    export LD  = $(CCPATH)/$(CROSS)-ld
+    export OC  = $(CCPATH)/$(CROSS)-objcopy
+    export OD  = $(CCPATH)/$(CROSS)-objdump
+    export AR  = $(CCPATH)/$(CROSS)-ar
+    export CPP = $(CCPATH)/$(CROSS)-cpp
 
-       CCFLAGS  = -Wall -fcommon -ffreestanding -Os -fno-delete-null-pointer-checks -m$(ENDIAN)-endian
-       CCFLAGS += -march=$(ARCH) -mabi=$(ABI) -I$(DARKLIBC)/include -I../$(DARKLIBC)/include
-       CCFLAGS += -D__RISCV__ -DBUILD="\"$(BUILD)\"" -DARCH="\"$(ARCH)\""
-export CCFLAGS += -mcmodel=medany -mexplicit-relocs # relocable clode
+       CFLAGS  = -Wall -fcommon -ffreestanding -Os -fno-delete-null-pointer-checks -m$(ENDIAN)-endian
+       CFLAGS += -march=$(ARCH) -mabi=$(ABI) -I$(DARKLIBC)/include -I../$(DARKLIBC)/include
+       CFLAGS += -D__RISCV__ -DBUILD="\"$(BUILD)\"" -DARCH="\"$(ARCH)\""
+export CFLAGS += -mcmodel=medany -mexplicit-relocs # relocatable code
 export ASFLAGS = -march=$(ARCH)
 
 ifdef ENDIAN==big

--- a/src/coremark/Makefile
+++ b/src/coremark/Makefile
@@ -30,7 +30,7 @@ include ../config.mk
 
 DFLAGS_STR = -DFLAGS_STR=\""-O2 -DPERFORMANCE_RUN=1"\"
 
-CCFLAGS += -I. -I./src $(DFLAGS_STR) -DITERATIONS=4000 -DPERFORMANCE_RUN=1 
+CFLAGS += -I. -I./src $(DFLAGS_STR) -DITERATIONS=4000 -DPERFORMANCE_RUN=1
 
 PROJ = coremark
 OBJS = ./src/core_main.o ./src/core_matrix.o ./src/core_list_join.o ./src/core_state.o ./src/core_util.o core_portme.o ee_printf.o 
@@ -53,7 +53,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(CC) $(CFLAGS) -S $< -o $@
 
 $(PROJ).a: $(OBJS) Makefile
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/src/coremark/core_portme.c
+++ b/src/coremark/core_portme.c
@@ -17,6 +17,8 @@ Original Author: Shay Gal-on
 */
 #include <io.h>
 #include <stdio.h>
+#include <string.h>     // memcpy..
+#include <unistd.h>     // usleep..
 #include "coremark.h"
 #include "core_portme.h"
 

--- a/src/darklibc/Makefile
+++ b/src/darklibc/Makefile
@@ -28,7 +28,7 @@
 
 include ../config.mk
 
-CCFLAGS += -Iinclude
+CFLAGS += -Iinclude
 
 PROJ = darklibc
 OBJS = stdio.o io.o string.o misc.o unistd.o util.o #small.o # start.o
@@ -51,7 +51,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(CC) $(CFLAGS) -S $< -o $@
 
 %.a: $(OBJS) Makefile
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/src/darklibc/include/stddef.h
+++ b/src/darklibc/include/stddef.h
@@ -31,6 +31,7 @@
 #ifndef __STDDEF__
 #define __STDDEF__
 
+typedef unsigned int size_t;
 #define EOF   -1
 #define NUL   0
 #define NULL  (void *)0

--- a/src/darkshell/Makefile
+++ b/src/darkshell/Makefile
@@ -32,7 +32,7 @@ include ../config.mk
 # SMALL = 1
 
 ifdef SMALL
-    CCFLAGS += -DSMALL
+    CFLAGS += -DSMALL
 endif
 
 PROJ = darkshell
@@ -56,7 +56,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(C) $(CFLAGS) -S $< -o $@
 
 $(PROJ).a: $(OBJS) Makefile
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/src/donut/Makefile
+++ b/src/donut/Makefile
@@ -32,7 +32,7 @@ include ../config.mk
 # SMALL = 1
 
 ifdef SMALL
-    CCFLAGS += -DSMALL
+    CFLAGS += -DSMALL
 endif
 
 PROJ = donut
@@ -56,7 +56,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(CC) $(CFLAGS) -S $< -o $@
 
 $(PROJ).a: $(OBJS) Makefile
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/src/mandelbrot/Makefile
+++ b/src/mandelbrot/Makefile
@@ -50,7 +50,7 @@ clean:
 	$(AS) $(ASFLAGS) -c $< -o $@
 
 %.s: %.c Makefile
-	$(CC) $(CCFLAGS) -S $< -o $@
+	$(CC) $(CFLAGS) -S $< -o $@
 
 $(PROJ).a: $(OBJS) Makefile
 	$(AR) $(ARFLAGS) $@ $(OBJS)


### PR DESCRIPTION
- Use standard CFLAGS macro
- Use lightweight/documented riscv32-embedded-elf toolchain by default
- Add missing headers in coremark
- Add missing size_t define in stddef.h