### PR TITLE
Add Linux Github Actions

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,0 +1,39 @@
+name: Linux
+
+on:
+  - push
+  - pull_request
+  - workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install prerequisites
+        run: |
+          pacman -Sy --noconfirm base-devel git wget iverilog
+          useradd -m builduser
+          echo 'builduser ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+          chown -R builduser /home/builduser
+
+      - name: Clone AUR package
+        run: |
+          sudo -u builduser git clone https://aur.archlinux.org/riscv32-gnu-toolchain-elf-bin.git /home/builduser/riscv32-toolchain
+
+      - name: Build and install toolchain
+        run: |
+          cd /home/builduser/riscv32-toolchain
+          sudo -u builduser makepkg -si --noconfirm
+          riscv32-unknown-elf-gcc -v
+
+      - name: Test
+        run: |
+          make
+
+      - name: Build and test
+        run: |
+          export CCPATH=$(dirname `command -v riscv32-unknown-elf-gcc`)
+          make clean all CROSS=riscv32-unknown-elf CCPATH=$CCPATH ARCH=rv32e_zicsr ABI=ilp32e ENDIAN=little

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # DarkRISCV
+[![Build Status][WorkflowBadgeLinux]][WorkflowUrlLinux]
+
 Opensource RISC-V implemented from scratch in one night!
 
 ![darkriscv](https://user-images.githubusercontent.com/42520878/109411184-01075f80-797f-11eb-8932-5b916133561a.jpg)
@@ -1244,3 +1246,6 @@ tested the *DarkRISCV*.
 	[4] https://abopen.com/news/darkriscv-an-overnight-bsd-licensed-risc-v-implementation/
 	[5] http://quasilyte.dev/blog/post/riscv32-custom-instruction-and-its-simulation/
 	[6] https://github.com/riscv/riscv-pk/blob/master/bbl/riscv_logo.txt
+
+[WorkflowBadgeLinux]: https://github.com/nsauzede/darkriscv/workflows/Linux/badge.svg
+[WorkflowUrlLinux]: https://github.com/nsauzede/darkriscv/actions/workflows/Linux.yml


### PR DESCRIPTION
[EDITED TO ONLY CONTAIN GHA CHANGES]

Trivial PR to add a basic Linux (archlinux) Github Actions CI, in order to help track regressions.

I guess that an extra commit will be needed after merge into upstream master, to fix the GHA Badge URLS currently pointing to my fork, in `README.md`, ie:
Change:
```yaml
[WorkflowBadgeLinux]: https://github.com/nsauzede/darkriscv/workflows/Linux/badge.svg
[WorkflowUrlLinux]: https://github.com/nsauzede/darkriscv/actions/workflows/Linux.yml
```
Into:
```yaml
[WorkflowBadgeLinux]: https://github.com/darklife/darkriscv/workflows/Linux/badge.svg
[WorkflowUrlLinux]: https://github.com/darklife/darkriscv/actions/workflows/Linux.yml
```
