### PR TITLE
Extend darksocv/darkio to 16-leds

### DIFF
--- a/boards/de10nano_cyclonev_mister/README.md
+++ b/boards/de10nano_cyclonev_mister/README.md
@@ -3,7 +3,7 @@
 ## General information
 The DE10-Nano board is a robust development board based on Intel/Altera Cyclone V family of FPGAs.\
 It has an Intel Cyclone® V SE 5CSEBA6U23I7 device (110K LEs) and also includes the following peripherals:
-* 64Mbit Flash Memory (EPCS64)
+* 64/128Mbit Flash Memory (EPCS64/128)
 * 800MHz Dual-core ARM Cortex-A9 processor (HPS)
 * 1GB DDR3 SDRAM (32-bit data bus, HPS)
 * 1 Gigabit Ethernet PHY with RJ45 connector (HPS)
@@ -11,8 +11,8 @@ It has an Intel Cyclone® V SE 5CSEBA6U23I7 device (110K LEs) and also includes 
 * HDMI TX, compatible with DVI 1.0 and HDCP v1.4
 * 8 LEDs + 2 push-buttons
 * Three 50 MHz clock sources
+* 3-axis accelerometer
 * Many headers: 40pins, Arduino R3, JTAG..
-* And more..
 
 NOTE: This Darkriscv port targets/integrates the MiSTer framework around the DE10-Nano.
 Some of their files are licensed under GPL v2+ (See LICENSE).
@@ -53,7 +53,7 @@ board: de10nano cyclonev mister (id=20)
 led = aa55
 1>
 ```
-You should see DEBUG on upper 4 leds, and LED on the lower ones.
+You should see 0x55 on the 8 leds.
 
 To clean the board-related objects:
 ```

--- a/boards/de10nano_cyclonev_mister/darkriscv_de10nano.sv
+++ b/boards/de10nano_cyclonev_mister/darkriscv_de10nano.sv
@@ -173,7 +173,9 @@ module emu
 assign ADC_BUS  = 'Z;
 assign USER_OUT = '1;
 //assign {UART_RTS, UART_TXD, UART_DTR} = 0;
+wire [15:0] the_16leds;
 wire [7:0] the_8leds;
+assign the_8leds = the_16leds[7:0];
 wire from_dut;
 wire to_dut;
 assign UART_TXD = from_dut;
@@ -182,7 +184,7 @@ assign {UART_RTS, UART_DTR} = 0;
     dut dut1 (
         .clk(CLK_50M),
         .reset(RESET),
-        .leds(the_8leds),
+        .leds(the_16leds),
         .tx(from_dut),
         .rx(to_dut)
     );

--- a/boards/de10nano_cyclonev_mister/dut.v
+++ b/boards/de10nano_cyclonev_mister/dut.v
@@ -4,19 +4,18 @@
 module dut (
     input rx,
     output tx,
-    output [7:0] leds,
+    output [15:0] leds,
     input reset,
     input clk
 );
 
-	 darksocv soc0 (
-		.UART_RXD(rx),  // UART receive line
-		.UART_TXD(tx),  // UART transmit line
+    darksocv soc0 (
+        .UART_RXD(rx),  // UART receive line
+        .UART_TXD(tx),  // UART transmit line
 
-		.LED(leds[3:0]),       // on-board leds
-		.DEBUG(leds[7:4]),      // osciloscope
+        .LED(leds),       // on-board leds
 
-		.XCLK(clk),      // external clock
-		.XRES(reset)      // external reset
-	);
+        .XCLK(clk),      // external clock
+        .XRES(reset)      // external reset
+    );
 endmodule

--- a/boards/max1000_max10/README.md
+++ b/boards/max1000_max10/README.md
@@ -9,7 +9,7 @@ It has a 10M08SAU169C8G chip and also includes the following peripherals:
 * 8 LEDs + 2 push-buttons
 * 12 MHz MEMS Oscillator
 * 3-axis accelerometer + thermal sensor
-* Many headers: PMOD, Arduino MKR, JTAG, I/O
+* Many headers: PMOD, Arduino MKR, JTAG, I/O..
 
 For more detailed information, see here:\
 https://wiki.trenz-electronic.de/display/PD/TEI0001+Getting+Started
@@ -41,7 +41,7 @@ board: max1000 max10 (id=19)
 led = aa55
 1>
 ```
-You should see DEBUG on upper 4 leds, and LED on the lower ones.
+You should see 0x55 on the 8 leds.
 
 To clean the board-related objects:
 ```

--- a/boards/max1000_max10/dut.v
+++ b/boards/max1000_max10/dut.v
@@ -4,19 +4,17 @@
 module dut (
     input rx,
     output tx,
-    output [7:0] leds,
+    output [15:0] leds,
     input reset,
     input clk
 );
+    darksocv soc0 (
+        .UART_RXD(rx),  // UART receive line
+        .UART_TXD(tx),  // UART transmit line
 
-	 darksocv soc0 (
-		.UART_RXD(rx),  // UART receive line
-		.UART_TXD(tx),  // UART transmit line
+        .LED(leds),       // on-board leds
 
-		.LED(leds[3:0]),       // on-board leds
-		.DEBUG(leds[7:4]),      // osciloscope
-
-		.XCLK(clk),      // external clock
-		.XRES(reset)      // external reset
-	);
+        .XCLK(clk),      // external clock
+        .XRES(reset)      // external reset
+    );
 endmodule

--- a/boards/max1000_max10/top.v
+++ b/boards/max1000_max10/top.v
@@ -14,10 +14,12 @@ module top (
         .inclk0(CLK12M),
         .c0(clk)
     );
+    wire [15:0] leds;
+    assign LED = leds[7:0];
     dut dut1 (
         .rx(BDBUS[0]),          // BDBUS[0] is USB UART TX (FPGA RX)
         .tx(BDBUS[1]),          // BDBUS[1] is USB UART RX (FPGA TX)
-        .leds(LED),
+        .leds(leds),
         .reset(~USER_BTN),
         .clk(clk)
     );

--- a/rtl/darkio.v
+++ b/rtl/darkio.v
@@ -55,7 +55,7 @@ module darkio
     input         ESIMACK,
 `endif
 
-    output [3:0]  LED,       // on-board leds
+    output [15:0]  LED,       // on-board leds
     output [3:0]  DEBUG      // osciloscope
 );
 
@@ -157,7 +157,7 @@ module darkio
     assign XIRQ = |BOARD_IRQ;
     
 `ifndef __TESTMODE__
-    assign LED = LEDFF[3:0];
+    assign LED = LEDFF;
 `endif
 
     // darkuart

--- a/rtl/darksocv.v
+++ b/rtl/darksocv.v
@@ -54,7 +54,7 @@ module darksocv
 
 `endif
 
-    output [3:0] LED,       // on-board leds
+    output [15:0] LED,       // on-board leds
     output [3:0] DEBUG      // osciloscope
 );
 


### PR DESCRIPTION
Darksocv/darkio are 16-leds-capable, phys constraints should be board-specific.
