### PR TITLE
Enhance spidemo

### DIFF
--- a/boards/de10nano_cyclonev_mister/README.md
+++ b/boards/de10nano_cyclonev_mister/README.md
@@ -42,8 +42,9 @@ One way to do this is to copy the RBF to your MiSTer via Ethernet, or using an U
 Finally to connect to the serial port, first ensure that the VT52 core SerialPort=ConsolePort;
 then you can use `screen` on the MiSTer via ssh:
 ```
-TERM=linux ssh -t root@<MiSTer_IP_Address> screen /dev/ttyS1 115200
+TERM=linux ssh -t root@mister screen /dev/ttyS1 115200
 ```
+(just replace `mister` by `<MiSTer_IP_Address>`)
 and you should see DarkRISCV booting up:
 ```
 ...

--- a/boards/max1000_max10/README.md
+++ b/boards/max1000_max10/README.md
@@ -31,7 +31,10 @@ Program the device like this:
 ```
 make install BOARD=max1000_max10
 ```
-Finally connect to the serial port, eg: with Putty on /dev/ttyUSB0 (baudrate=115200)
+Finally connect at baudrate=115200 to the serial port (eg: /dev/ttyUSB0 or /dev/ttyUSB1) with `screen` (or any other terminal like Putty, etc..):
+```shell
+screen /dev/ttyUSB? 115200
+```
 and you should see DarkRISCV booting up:
 ```
 ...


### PR DESCRIPTION
This small PR make the `spidemo` a bit more useful on board `max1000_max10` (using LIS3DH in SPI mode).

- [x] Better calibrate spidemo input range
- [x] autostart the sensor demo if found (can be interrupted)
- [x] supports `reboot` command as well


Ideas to self for future work:
- [ ] try and communicate with the LIS3DH sensor using I2C
- [ ] try and support the ADXL345 SPI/I2C accelero sensor for board `de10nano_cyclonev_mister`