### PR TITLE
Improve GPIOs

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -29,11 +29,11 @@ jobs:
           sudo -u builduser makepkg -si --noconfirm
           riscv32-unknown-elf-gcc -v
 
-      - name: Test
+      - name: Test (darksocv.mem already built)
         run: |
           make
 
-      - name: Build and test
+      - name: Rebuild and test
         run: |
           export CCPATH=$(dirname `command -v riscv32-unknown-elf-gcc`)
           make clean all CROSS=riscv32-unknown-elf CCPATH=$CCPATH ARCH=rv32e_zicsr ABI=ilp32e ENDIAN=little

--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ With the option __THREADING__ is possible test this feature.
 
 The implementation is in very early stages of development and does not
 handle correctly the initial SP and PC.  Anyway, it works and enables the
-main() code stop in a gets() while the interrupt handling changes the GPIO
+main() code stop in a gets() while the interrupt handling changes the OPORT
 at a rate of more than 1 million interrupts per second without affecting the
 execution and with little impact in the performance!  :)
 
@@ -1051,7 +1051,8 @@ In the software side, a small shell is available with some basic commands:
 - dump <val>: dumps an area of the RAM
 - led <val>: change the LED register (which turns on/off the LEDs)
 - timer <val>: change the timer prescaler, which affects the interrupt rate
-- gpio <val>: change the GPIO register (which changes the DEBUG lines)
+- oport <val>: change the OPORT register (which changes the DEBUG lines)
+- iport: print the OPORT register
 
 The proposal of the shell is provide some basic test features which can
 provide a go/non-go status about the current hardware status.

--- a/boards/de10nano_cyclonev_mister/darksocv.mk
+++ b/boards/de10nano_cyclonev_mister/darksocv.mk
@@ -76,4 +76,5 @@ install: $(BIT)
 
 clean:
 	rm -f $(BRD)/memory_init.mif $(BRD)/memory_init.mem $(BRD)/memory_init.bin
+	rm -f $(BRD)/build_id.v $(BRD)/c5_pin_model_dump.txt
 	rm -rf $(BRD)/db $(BRD)/incremental_db $(BRD)/output_files

--- a/boards/de10nano_cyclonev_mister/jtag.cdf
+++ b/boards/de10nano_cyclonev_mister/jtag.cdf
@@ -1,0 +1,13 @@
+JedecChain;
+	FileRevision(JESD32A);
+	DefaultMfr(6E);
+
+	P ActionCode(Ign)
+		Device PartName(SOCVHPS) MfrSpec(OpMask(0));
+	P ActionCode(Cfg)
+		Device PartName(5CSEBA6U23I7) Path("output_files/") File("darkriscv_de10nano.sof") MfrSpec(OpMask(1));
+ChainEnd;
+
+AlteraBegin;
+	ChainType(JTAG);
+AlteraEnd;

--- a/boards/max1000_max10/dut.v
+++ b/boards/max1000_max10/dut.v
@@ -9,13 +9,14 @@ module dut (
     output spi_mosi,
     output spi_csn,
     output spi_sck,
-    inout [15:0] gpio,
 `endif
+    inout [8:1] pio,
     output [15:0] leds,
     input reset,
     input clk
 );
-    input [31:0] iport;
+    wire [15:0] gpio;
+    wire [31:0] iport;
     darksocv soc0 (
         .UART_RXD(rx),  // UART receive line
         .UART_TXD(tx),  // UART transmit line
@@ -24,13 +25,22 @@ module dut (
         .SPI_MOSI(spi_mosi),    // SPI master data output, slave data input
         .SPI_MISO(spi_miso),    // SPI master data input, slave data output
         .SPI_CSN(spi_csn),      // SPI CSN output (active LOW)
-`else
-        .GPIO(gpio),
-        .IPORT(iport),
 `endif
         .LED(leds),       // on-board leds
+        .GPIO(gpio),
+        .IPORT(iport),
 
         .XCLK(clk),      // external clock
         .XRES(reset)      // external reset
     );
+    wire [3:0] pmbuttons;
+    wire [3:0] pmleds;
+    assign pmleds = gpio[3:0];
+    assign iport = {24'b0, pmbuttons};
+    pmodbutled pmodbutled1(
+        .pio(pio),
+        .buttons(pmbuttons),
+        .leds(pmleds)
+    );
+
 endmodule

--- a/boards/max1000_max10/dut.v
+++ b/boards/max1000_max10/dut.v
@@ -11,11 +11,11 @@ module dut (
     output spi_sck,
 `endif
     inout [8:1] pio,
-    output [15:0] leds,
+    output [31:0] leds,
     input reset,
     input clk
 );
-    wire [15:0] gpio;
+    wire [31:0] oport;
     wire [31:0] iport;
     darksocv soc0 (
         .UART_RXD(rx),  // UART receive line
@@ -27,15 +27,15 @@ module dut (
         .SPI_CSN(spi_csn),      // SPI CSN output (active LOW)
 `endif
         .LED(leds),       // on-board leds
-        .GPIO(gpio),
         .IPORT(iport),
+        .OPORT(oport),
 
         .XCLK(clk),      // external clock
         .XRES(reset)      // external reset
     );
     wire [3:0] pmbuttons;
     wire [3:0] pmleds;
-    assign pmleds = gpio[3:0];
+    assign pmleds = oport[3:0];
     assign iport = {24'b0, pmbuttons};
     pmodbutled pmodbutled1(
         .pio(pio),

--- a/boards/max1000_max10/dut.v
+++ b/boards/max1000_max10/dut.v
@@ -9,11 +9,13 @@ module dut (
     output spi_mosi,
     output spi_csn,
     output spi_sck,
+    inout [15:0] gpio,
 `endif
     output [15:0] leds,
     input reset,
     input clk
 );
+    input [31:0] iport;
     darksocv soc0 (
         .UART_RXD(rx),  // UART receive line
         .UART_TXD(tx),  // UART transmit line
@@ -22,6 +24,9 @@ module dut (
         .SPI_MOSI(spi_mosi),    // SPI master data output, slave data input
         .SPI_MISO(spi_miso),    // SPI master data input, slave data output
         .SPI_CSN(spi_csn),      // SPI CSN output (active LOW)
+`else
+        .GPIO(gpio),
+        .IPORT(iport),
 `endif
         .LED(leds),       // on-board leds
 

--- a/boards/max1000_max10/pmodbutled.v
+++ b/boards/max1000_max10/pmodbutled.v
@@ -1,0 +1,37 @@
+/*
+IMPORTANT:
+Must place the Papilio wingbutled only on the rightmost PMOD PIO pins,
+ie: avoid all 3.3V/GND pins!
+Pmod    Wing    Out     In
+PIO_08  GND     0
+PIO_07  2V5     z
+PIO_06  3V3     1
+PIO_05  5V      z
+PIO_04  LED4    leds[1]
+PIO_03  PB4     z       buttons[1]
+PIO_02  LED3    leds[0]
+PIO_01  PB3     z       buttons[0]
+*/
+module pmodbutled (
+    inout [8:1] pio,
+    output [3:0] buttons,
+    input [3:0] leds
+);
+    // Assign leds values to specific io pins
+    assign pio[4] = leds[1];
+    assign pio[2] = leds[0];
+
+    assign pio[8] = 1'b0;       // GND
+    assign pio[6] = 1'b1;       // 3V3
+
+    // Set specific io pins to high impedance (Z)
+    assign pio[7] = 1'bz;       // 2V5
+    assign pio[5] = 1'bz;       // 5V
+    assign pio[3] = 1'bz;
+    assign pio[1] = 1'bz;
+
+    // Assign io pin values to button outputs
+    assign buttons[1] = pio[3];
+    assign buttons[0] = pio[1];
+endmodule
+

--- a/boards/max1000_max10/top.v
+++ b/boards/max1000_max10/top.v
@@ -20,7 +20,7 @@ module top (
         .inclk0(CLK12M),
         .c0(clk)
     );
-    wire [15:0] leds;
+    wire [31:0] leds;
     assign LED = leds[7:0];
     dut dut1 (
         .rx(BDBUS[0]),          // BDBUS[0] is USB UART TX (FPGA RX)

--- a/boards/max1000_max10/top.v
+++ b/boards/max1000_max10/top.v
@@ -32,7 +32,7 @@ module top (
         .spi_csn(SEN_CS),
         .spi_miso(SEN_SDO),
 `endif
-        .gpio(PIO),
+        .pio(PIO),
         .reset(~USER_BTN),
         .clk(clk)
     );

--- a/boards/max1000_max10/top.v
+++ b/boards/max1000_max10/top.v
@@ -32,6 +32,7 @@ module top (
         .spi_csn(SEN_CS),
         .spi_miso(SEN_SDO),
 `endif
+        .gpio(PIO),
         .reset(~USER_BTN),
         .clk(clk)
     );

--- a/boards/scarab_minispartan6-plus_lx9/README.md
+++ b/boards/scarab_minispartan6-plus_lx9/README.md
@@ -86,7 +86,7 @@ mtvec: interrupts enabled!
 Welcome to DarkRISCV!
 > ?
 command: [?] not found.
-valid commands: clear, dump [hex], led [hex], timer [dec], gpio [hex]
+valid commands: clear, dump [hex], led [hex], timer [dec], oport [hex]
                 mul [dec] [dec], div [dec] [dec], mac [dec] [dec] [dec]
                 reboot, wr[m][bwl] [hex] [hex] [[hex] when m],
                 rd[m][bwl] [hex] [[hex] when m]

--- a/rtl/config.vh
+++ b/rtl/config.vh
@@ -74,7 +74,7 @@
 // a) threading is currently supported only in the 3-stage pipeline version.
 // b) the old experimental "interrupt mode" was removed, which means that
 //    the multi-thread mode does not make anything "visible" other than
-//    increment the gpio register.
+//    increment the oport register.
 // c) the threading in the non-interrupt mode switches when the program flow
 //    changes, i.e. every jal instruction. When the core is idle, it is
 //    probably in a jal loop.

--- a/rtl/darkio.v
+++ b/rtl/darkio.v
@@ -64,8 +64,12 @@ module darkio
     input         ESIMACK,
 `endif
 
-    output [15:0]  LED,       // on-board leds
-    output [3:0]  DEBUG      // osciloscope
+    output [15:0] LED,  // on-board leds / general-purpose outputs lo
+    output [15:0] GPIO, // general-purpose outputs hi
+`ifndef SPI
+    input [31:0]  IPORT,// general-purpose inputs
+`endif
+    output [3:0]  DEBUG // osciloscope
 );
 
     // io block
@@ -101,7 +105,7 @@ module darkio
 
 `ifdef SPI
 `ifdef SIMULATION
-    reg [15:0] out_x_l_response = 0;
+    reg [15:0] out_x_l_response = 0;    // SPI slave LIS3DH stub
 `endif
 `endif
     always@(posedge CLK)
@@ -129,14 +133,18 @@ module darkio
                                 IACK[1] <= XATAI[1+24] ? IREQ[1] : IACK[1];
                                 IACK[0] <= XATAI[0+24] ? IREQ[0] : IACK[0];
                             end
-                5'b010xx:   { GPIOFF, LEDFF } <= {  XBE[3] ? XATAI[31:24] : GPIOFF[15:8],
+                5'b010xx:   begin { GPIOFF, LEDFF } <= {  XBE[3] ? XATAI[31:24] : GPIOFF[15:8],
                                                     XBE[2] ? XATAI[23:16] : GPIOFF[ 7:0],
                                                     XBE[1] ? XATAI[15: 8] : LEDFF [15:8],
                                                     XBE[0] ? XATAI[ 7: 0] : LEDFF [ 7:0] };
+                            $display("*** SIM: current GPIO=%x LED=%x bus %x XBE=%b XADDR=%x",GPIOFF,LEDFF,XATAI,XBE,XADDR);
+                            end
                 5'b01100:   TIMERFF <= XATAI[31:0];
 `ifdef SPI
 `ifdef SIMULATION
-                5'b11000:   out_x_l_response <= XATAI[15:0];    // SPI slave LIS3DH stub
+                5'b10110:   begin out_x_l_response <= XATAI[31:16];    // SPI slave LIS3DH stub
+                            $display("*** SIM: current out_x_l_response=%x bus %x XBE=%b XADDR=%x",out_x_l_response,XATAI,XBE,XADDR);
+                            end
 `endif
 `endif
             endcase
@@ -170,6 +178,8 @@ module darkio
                 5'b100xx:   IOMUXFF <= TIMEUS;
 `ifdef SPI
                 5'b101xx:   IOMUXFF <= SDATA; // from spi
+`else
+                5'b101xx:   IOMUXFF <= IPORT;
 `endif
             endcase
         end

--- a/rtl/darkio.v
+++ b/rtl/darkio.v
@@ -66,9 +66,7 @@ module darkio
 
     output [15:0] LED,  // on-board leds / general-purpose outputs lo
     output [15:0] GPIO, // general-purpose outputs hi
-`ifndef SPI
     input [31:0]  IPORT,// general-purpose inputs
-`endif
     output [3:0]  DEBUG // osciloscope
 );
 
@@ -137,13 +135,13 @@ module darkio
                                                     XBE[2] ? XATAI[23:16] : GPIOFF[ 7:0],
                                                     XBE[1] ? XATAI[15: 8] : LEDFF [15:8],
                                                     XBE[0] ? XATAI[ 7: 0] : LEDFF [ 7:0] };
-                            $display("*** SIM: current GPIO=%x LED=%x bus %x XBE=%b XADDR=%x",GPIOFF,LEDFF,XATAI,XBE,XADDR);
+                            //$display("*** SIM: current GPIO=%x LED=%x bus %x XBE=%b XADDR=%x",GPIOFF,LEDFF,XATAI,XBE,XADDR);
                             end
                 5'b01100:   TIMERFF <= XATAI[31:0];
 `ifdef SPI
 `ifdef SIMULATION
                 5'b10110:   begin out_x_l_response <= XATAI[31:16];    // SPI slave LIS3DH stub
-                            $display("*** SIM: current out_x_l_response=%x bus %x XBE=%b XADDR=%x",out_x_l_response,XATAI,XBE,XADDR);
+                            //$display("*** SIM: current out_x_l_response=%x bus %x XBE=%b XADDR=%x",out_x_l_response,XATAI,XBE,XADDR);
                             end
 `endif
 `endif
@@ -178,9 +176,8 @@ module darkio
                 5'b100xx:   IOMUXFF <= TIMEUS;
 `ifdef SPI
                 5'b101xx:   IOMUXFF <= SDATA; // from spi
-`else
-                5'b101xx:   IOMUXFF <= IPORT;
 `endif
+                5'b110xx:   IOMUXFF <= IPORT;
             endcase
         end
     end
@@ -195,6 +192,7 @@ module darkio
 `ifndef __TESTMODE__
     assign LED = LEDFF;
 `endif
+    assign GPIO = GPIOFF;
 
     // darkuart
 

--- a/rtl/darksocv.v
+++ b/rtl/darksocv.v
@@ -46,7 +46,10 @@ module darksocv
     output       SPI_MOSI,  // SPI master data output, slave data input
     input        SPI_MISO,  // SPI master data input, slave data output
     output        SPI_CSN,  // SPI CSN output (active LOW)
+`else
+    input [31:0]  IPORT,
 `endif
+    output [15:0] GPIO,
 
 `ifdef __SDRAM__
 

--- a/rtl/darksocv.v
+++ b/rtl/darksocv.v
@@ -63,9 +63,9 @@ module darksocv
 
 `endif
 
-    output [15:0] LED,       // on-board leds
-    output [15:0] GPIO,
+    output [31:0] LED,       // on-board leds
     input  [31:0] IPORT,
+    output [31:0] OPORT,
     output [3:0] DEBUG      // osciloscope
 );
 
@@ -254,8 +254,8 @@ module darksocv
         .CSN    (SPI_CSN),
 `endif
         .LED    (LED),
-        .GPIO   (GPIO),
         .IPORT  (IPORT),
+        .OPORT  (OPORT),
 
 `ifdef SIMULATION
         .ESIMREQ(ESIMREQ),

--- a/rtl/darksocv.v
+++ b/rtl/darksocv.v
@@ -46,10 +46,7 @@ module darksocv
     output       SPI_MOSI,  // SPI master data output, slave data input
     input        SPI_MISO,  // SPI master data input, slave data output
     output        SPI_CSN,  // SPI CSN output (active LOW)
-`else
-    input [31:0]  IPORT,
 `endif
-    output [15:0] GPIO,
 
 `ifdef __SDRAM__
 
@@ -67,6 +64,8 @@ module darksocv
 `endif
 
     output [15:0] LED,       // on-board leds
+    output [15:0] GPIO,
+    input  [31:0] IPORT,
     output [3:0] DEBUG      // osciloscope
 );
 
@@ -255,6 +254,8 @@ module darksocv
         .CSN    (SPI_CSN),
 `endif
         .LED    (LED),
+        .GPIO   (GPIO),
+        .IPORT  (IPORT),
 
 `ifdef SIMULATION
         .ESIMREQ(ESIMREQ),

--- a/rtl/darkspi.v
+++ b/rtl/darkspi.v
@@ -113,14 +113,14 @@ module darkspi #(parameter integer DIV_COEF = 0) (
                 NWR <= NWR + 1;
                 spi_request <= 1;
                 if (BE == 4'b1111) begin
-                    spi_nbits <= 6'd23;
+                    spi_nbits <= 6'd23;                 // 24 bits
                     spi_mosi_data <= DATAI;
                 end else if (BE == 4'b0011) begin
-                    spi_nbits <= 6'd15;
+                    spi_nbits <= 6'd15;                 // 16 bits
                     spi_mosi_data <= DATAI[15:0];
 //                    spi_mosi_data <= {DATAI[7:0], DATAI[15:8]};
                 end else begin
-                    spi_request <= 0;
+                    spi_request <= 0;                   // ignore any other writes
                 end
             end else begin
                 spi_request <= 0;

--- a/src/darklibc/include/io.h
+++ b/src/darklibc/include/io.h
@@ -56,17 +56,20 @@ struct DARKIO {
 
     struct DARKSPI {
         union {
-            unsigned char      spi8;           // 14                                                   r: {data}
-            unsigned short      spi16;          // 14/15/16/17        w: {command,data}                 r: {datalo,datahi}
-            unsigned int        spi24;          // 14/15/16/17        w: {00,command,datalo,datahi}     r: {status,00,datalo,datahi}
-            unsigned int        spi32;          // 14/15/16/17        w: {00,command,datalo,datahi}     r: {status,00,datalo,datahi}
-//            struct {
-//                unsigned char ignore__[3];
-//                unsigned char status;           // 17                                                   r: {status}
-//            };
+            unsigned char      spi8;                    // 14                                           r: {data}
+            unsigned short      spi16;                  // 14/15        w: {command,data}               r: {datalo,datahi}
+            unsigned int        spi32;                  // 14/15/16/17  w: {00,command,datalo,datahi}   r: {status,00,datalo,datahi}
+/*          struct {
+                unsigned char ignore0__[3];
+                unsigned char status;                   // 17                                           r: {status}
+            };*/
+            struct {
+                unsigned char ignore1__[2];
+                unsigned short out_x_l_response;        // 16/17        ONLY FOR SIMULATION : LIS3DH stub out_x_l_response
+            };
         };
-        unsigned short out_x_l_response;    // 18/19        ONLY FOR SIMULATION : LIS3DH stub out_x_l_response
     } spi;
+    unsigned int iport;     // 18
 };
 
 extern volatile struct DARKIO *io;

--- a/src/darklibc/include/io.h
+++ b/src/darklibc/include/io.h
@@ -48,33 +48,32 @@ struct DARKIO {
 
     } uart;
 
-    unsigned short led;     // 08/09
-    unsigned short gpio;    // 0a/0b
-
-    unsigned int timer;     // 0c
-    unsigned int timeus;    // 10
+    unsigned int led;        // 08
+    unsigned int timer;      // 0c
+    unsigned int timeus;     // 10
+    unsigned int iport;      // 14
+    unsigned int oport;      // 18
 
     struct DARKSPI {
         union {
-            unsigned char      spi8;                    // 14                                           r: {data}
-            unsigned short      spi16;                  // 14/15        w: {command,data}               r: {datalo,datahi}
-            unsigned int        spi32;                  // 14/15/16/17  w: {00,command,datalo,datahi}   r: {status,00,datalo,datahi}
+            unsigned char      spi8;                   // 1c                                           r: {data}
+            unsigned short     spi16;                  // 1c/1d        w: {command,data}               r: {datalo,datahi}
+            unsigned int       spi32;                  // 1c/1d/1e/1f  w: {00,command,datalo,datahi}   r: {status,00,datalo,datahi}
 /*          struct {
                 unsigned char ignore0__[3];
-                unsigned char status;                   // 17                                           r: {status}
+                unsigned char status;                  // 1f                                           r: {status}
             };*/
             struct {
-                unsigned char ignore1__[2];
+                unsigned char  ignore1__[2];
                 // This is hack to feed an SPI (simulation) stub with an expected value.
                 // It is voluntarily embedded/hidden within the regular SPI master address range.
                 // In order to write to it, we must generate special XBE=1100, which is ignored by SPI master ofc.
                 // It is then fed to the SPI stub within darkio itself.
-                unsigned short out_x_l_response;        // 16/17        ONLY FOR SIMULATION : LIS3DH stub out_x_l_response
+                unsigned short out_x_l_response;       // 1e/1f     ONLY FOR SIMULATION : LIS3DH stub out_x_l_response
             };
         };
     } spi;
 
-    unsigned int iport;     // 18
 };
 
 extern volatile struct DARKIO *io;

--- a/src/darklibc/include/io.h
+++ b/src/darklibc/include/io.h
@@ -65,10 +65,15 @@ struct DARKIO {
             };*/
             struct {
                 unsigned char ignore1__[2];
+                // This is hack to feed an SPI (simulation) stub with an expected value.
+                // It is voluntarily embedded/hidden within the regular SPI master address range.
+                // In order to write to it, we must generate special XBE=1100, which is ignored by SPI master ofc.
+                // It is then fed to the SPI stub within darkio itself.
                 unsigned short out_x_l_response;        // 16/17        ONLY FOR SIMULATION : LIS3DH stub out_x_l_response
             };
         };
     } spi;
+
     unsigned int iport;     // 18
 };
 

--- a/src/darklibc/io.c
+++ b/src/darklibc/io.c
@@ -43,8 +43,10 @@ volatile struct DARKIO io =
     4, 100, 0, 0,   // ctrl = { board id, fMHz, fkHz }
     { 0, 0, 0 },    // uart = { stat, fifo, baud }
     0,              // led
-    0,              // gpio
-    1000000         // timer
+    1000000,        // timer
+    0,              // timerus
+    0,              // iport
+    0               // oport
 };
 
 unsigned char kmem[8192] = "darksocv x86 payload test";

--- a/src/darkshell/main.c
+++ b/src/darkshell/main.c
@@ -138,15 +138,14 @@ int main(void)
 
     printf("uart0: 115.2kbps (div=%d)\n",io->uart.baud);
     printf("timr0: %dHz (div=%d)\n",(io->board_cm*2000000u)/(io->timer+1),io->timer);
-/*
-    // gpio/led test code! :)
+#if 0
+    // led test code! :)
 
-    printf("*** gpio=%x, led=%x\n",io->gpio,io->led);
+    printf("*** led=%x\n",io->led);
     
-    io->gpio = 0x5555;
-    io->led  = 0xaaaa;
+    io->led  = 0x5555aaaa;
 
-    printf("*** gpio=%x, led=%x\n",io->gpio,io->led);
+    printf("*** led=%x\n",io->led);
 
     volatile char *p = (char *)&io->led;
 
@@ -155,8 +154,8 @@ int main(void)
     p[2] = 2;
     p[3] = 3;
     
-    printf("*** gpio=%x, led=%x\n",io->gpio,io->led);
-*/
+    printf("*** led=%x\n",io->led);
+#endif
     // simulate a 32-bit load in a invalid address
 
     if(stvec)
@@ -324,11 +323,11 @@ int main(void)
               printf("timer = %d\n",io->timer);
           }
           else
-          if(!strcmp(argv[0],"gpio"))
+          if(!strcmp(argv[0],"oport"))
           {
-              if(argv[1]) io->gpio = xtoi(argv[1]);
+              if(argv[1]) io->oport = xtoi(argv[1]);
 
-              printf("gpio = %x\n",io->gpio);
+              printf("oport = %x\n",io->oport);
           }
           else
           if(!strcmp(argv[0],"iport"))
@@ -370,10 +369,10 @@ int main(void)
           if(argv[0][0])
           {
               printf("command: [%s] not found.\n"
-                     "valid commands: clear, dump [hex], led [hex], timer [dec], gpio [hex]\n"
+                     "valid commands: clear, dump [hex], led [hex], timer [dec], oport [hex]\n"
                      "                mul [dec] [dec], div [dec] [dec], mac [dec] [dec] [dec]\n"
                      "                reboot, wr[m][bwl] [hex] [hex] [[hex] when m],\n"
-                     "                rd[m][bwl] [hex] [[hex] when m]\n",
+                     "                rd[m][bwl] [hex] [[hex] when m], iport\n",
                      argv[0]);
           }
 

--- a/src/darkshell/main.c
+++ b/src/darkshell/main.c
@@ -331,6 +331,11 @@ int main(void)
               printf("gpio = %x\n",io->gpio);
           }
           else
+          if(!strcmp(argv[0],"iport"))
+          {
+              printf("iport = %x\n",io->iport);
+          }
+          else
           if(!strcmp(argv[0],"mul"))
           {
               int x = atoi(argv[1]);

--- a/src/spidemo/Makefile
+++ b/src/spidemo/Makefile
@@ -1,20 +1,20 @@
-# Copyright (c) 2018, Marcelo Samsoniuk
+# Copyright (c) 2025, Nicolas Sauzede <nicolas.sauzede@gmail.com>
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright notice,
 #   this list of conditions and the following disclaimer in the documentation
 #   and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of the copyright holder nor the names of its
 #   contributors may be used to endorse or promote products derived from
 #   this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -24,7 +24,7 @@
 # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 include ../config.mk
 

--- a/src/spidemo/main.c
+++ b/src/spidemo/main.c
@@ -55,8 +55,7 @@ unsigned short spi_transfer16(unsigned short command_data) {
 
 unsigned int spi_transfer24(unsigned int command_data) {
     unsigned int ret = -1;
-//    io->spi.spi32 = command_data & 0xffffff;
-    io->spi.spi24 = command_data & 0xffffff;
+    io->spi.spi32 = command_data & 0xffffff;
     for (int i = 0; i < 1000000; i++) {
         int status = 0;
 //        status = io->spi.spi32;

--- a/src/spidemo/main.c
+++ b/src/spidemo/main.c
@@ -38,7 +38,7 @@ unsigned short spi_transfer16(unsigned short command_data) {
     io->spi.spi16 = command_data;
     for (int i = 0; i < 1000000; i++) {
         int status = 0;
-        status = *(volatile unsigned char *)((volatile char *)io + 0x14 + 3);
+        status = *(volatile unsigned char *)((volatile char *)io + 0x1c + 3);
 //        if (status & 0x2000000) {
         if (status & 0x2) {
             ret = io->spi.spi8;
@@ -57,7 +57,7 @@ unsigned int spi_transfer24(unsigned int command_data) {
     for (int i = 0; i < 1000000; i++) {
         int status = 0;
 //        status = io->spi.spi32;
-        status = *(volatile unsigned char *)((volatile char *)io + 0x14 + 3);
+        status = *(volatile unsigned char *)((volatile char *)io + 0x1c + 3);
 //        if (status & 0x2000000) {
         if (status & 0x2) {
 //            ret = status & 0xffffff;

--- a/src/spidemo/main.c
+++ b/src/spidemo/main.c
@@ -33,8 +33,6 @@
 #include <string.h>
 #include <math.h>
 
-unsigned csr_test(unsigned,unsigned,unsigned);
-
 unsigned short spi_transfer16(unsigned short command_data) {
     unsigned short ret = -1;
     io->spi.spi16 = command_data;
@@ -91,7 +89,7 @@ int simu() {
     spi_transfer16(0x2388);
     exp = 0x9a00;
     for (int i = 0; i < 1000000; i++) {
-        printf("i=%d\n", i);
+        //printf("i=%d\n", i);
         io->spi.out_x_l_response = exp;
         ret = spi_transfer24(0xe80000);
         if (ret != exp) {


### PR DESCRIPTION
The goal here is to improve the gpios and other io mapping.

- [x] Map the `out_x_l_response` SPI sim reg within the existing SPI Master range (save space)
- [x] Expose darkio `iport`/`oport` i/o ports (replaces `gpio`), add `iport` darkshell command
- [x] Consolidate most io fields to 32 bits
- [x] Move SPI regs to the end of the mapping (as long as it is optional)
