### PR TITLE
Cleanup SPI, add bitbanging

### DIFF
--- a/boards/max1000_max10/dut.v
+++ b/boards/max1000_max10/dut.v
@@ -5,10 +5,10 @@ module dut (
     input rx,
     output tx,
 `ifdef SPI
-    input spi_miso,
-    output spi_mosi,
     output spi_csn,
     output spi_sck,
+    output spi_mosi,
+    input spi_miso,
 `endif
     inout [8:1] pio,
     output [31:0] leds,
@@ -33,6 +33,7 @@ module dut (
         .XCLK(clk),      // external clock
         .XRES(reset)      // external reset
     );
+`ifndef SPIBB
     wire [3:0] pmbuttons;
     wire [3:0] pmleds;
     assign pmleds = oport[3:0];
@@ -42,5 +43,6 @@ module dut (
         .buttons(pmbuttons),
         .leds(pmleds)
     );
+`endif
 
 endmodule

--- a/boards/max1000_max10/max1000.qsf
+++ b/boards/max1000_max10/max1000.qsf
@@ -267,6 +267,7 @@ set_global_assignment -name EDA_TEST_BENCH_FILE dut_tb.v -section_id dut_tb
 set_global_assignment -name VERILOG_MACRO "QUARTUS=1"
 set_global_assignment -name VERILOG_MACRO "MAX1000_MAX10=1"
 set_global_assignment -name VERILOG_MACRO "SPI=1"
+set_global_assignment -name VERILOG_MACRO "SPIBB=1"
 set_global_assignment -name VERILOG_FILE ../../rtl/darksocv.v
 set_global_assignment -name VERILOG_FILE ../../rtl/darkio.v
 set_global_assignment -name VERILOG_FILE ../../rtl/darkpll.v
@@ -275,6 +276,7 @@ set_global_assignment -name VERILOG_FILE ../../rtl/darkriscv.v
 set_global_assignment -name VERILOG_FILE ../../rtl/darkbridge.v
 set_global_assignment -name VERILOG_FILE ../../rtl/darkspi.v
 set_global_assignment -name VERILOG_FILE ../../rtl/lib/spi/spi_master.v
+set_global_assignment -name VERILOG_FILE ../../rtl/lib/spi/spi_master_bb.v
 set_global_assignment -name VERILOG_FILE dut.v
 set_global_assignment -name VERILOG_FILE top.v
 set_global_assignment -name VERILOG_FILE _darkram.v

--- a/rtl/darkspi.v
+++ b/rtl/darkspi.v
@@ -65,27 +65,27 @@
 // short swapped_out_x = *((volatile short *)SPI_MMADDR); // Note that the returned value is byte-swapped: 0xLOHI
 
 module darkspi #(parameter integer DIV_COEF = 0) (
-    input           CLK,            // clock
-    input           RES,            // reset
+    input         CLK,          // clock
+    input         RES,          // reset
 
-    input           RD,             // bus read
-    input           WR,             // bus write
-    input  [ 3:0]   BE,             // byte enable
-    input  [31:0]   DATAI,          // data input
-    output [31:0]   DATAO,          // data output
-    output          IRQ,            // interrupt req
+    input         RD,           // bus read
+    input         WR,           // bus write
+    input  [ 3:0] BE,           // byte enable
+    input  [31:0] DATAI,        // data input
+    output [31:0] DATAO,        // data output
+    output        IRQ,          // interrupt req
 
-    output          SCK,            // SPI clock output
-    output         MOSI,            // SPI master data output, slave data input
-    input          MISO,            // SPI master data input, slave data output
-    output          CSN,            // SPI CSN output (active LOW)
+    inout         CSN,          // SPI CSN output (active LOW)
+    inout         SCK,          // SPI clock output
+    inout         MOSI,         // SPI master data output, slave data input
+    input         MISO,         // SPI master data input, slave data output
 
 `ifdef SIMULATION
     output reg    ESIMREQ = 0,
-    input           ESIMACK,
+    input         ESIMACK,
 `endif
 
-    output [3:0]    DEBUG           // osc debug
+    output [3:0]  DEBUG         // osc debug
 );
 
     reg [8:0] NWR = 0;
@@ -118,7 +118,6 @@ module darkspi #(parameter integer DIV_COEF = 0) (
                 end else if (BE == 4'b0011) begin
                     spi_nbits <= 6'd15;                 // 16 bits
                     spi_mosi_data <= DATAI[15:0];
-//                    spi_mosi_data <= {DATAI[7:0], DATAI[15:8]};
                 end else begin
                     spi_request <= 0;                   // ignore any other writes
                 end

--- a/rtl/lib/spi/spi_master_bb.v
+++ b/rtl/lib/spi/spi_master_bb.v
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, Nicolas Sauzede <nicolas.sauzede@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+`timescale 1ns / 1ps
+//`include "../../../rtl/config.vh"
+
+module spi_master_bb (
+    input               CLK,    // clock
+    input               RES,    // reset
+
+    inout [31:0]        IPORT,
+    input [31:0]        OPORT,
+
+    inout               CSN,    // SPI CSN output (active LOW)
+    inout               SCK,    // SPI clock output
+    inout               MOSI,   // SPI master data output, slave data input
+    inout               MISO    // SPI master data input, slave data output
+);
+
+    wire spibb_ena;
+    reg [15:0] out_x_resp = 16'bz;
+    reg [31:0] IPORTFF = 32'bz;
+    assign spibb_ena = OPORT[3];
+    assign IPORT = spibb_ena ? IPORTFF : 32'bz;
+    assign CSN = spibb_ena ? OPORT[2] : 1'bz;
+    assign SCK = spibb_ena ? OPORT[1] : 1'bz;
+    assign MOSI = spibb_ena ? OPORT[0] : 1'bz;
+    always@(posedge CLK) begin
+        if (RES) begin
+            out_x_resp <= 16'bz;
+        end else if (spibb_ena) begin
+            out_x_resp <= OPORT[31:16];
+        end
+    end
+    always@(posedge CLK) begin
+        if (RES) begin
+            IPORTFF <= 32'b0;
+        end else if (spibb_ena & !CSN) begin
+            IPORTFF <= {out_x_resp, 11'b0, MISO, spibb_ena, CSN, SCK, MOSI};
+        end
+    end
+endmodule

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -46,6 +46,12 @@ ICARUS += -DSPI=1
 RTLS += ../rtl/darkspi.v                \
         ../rtl/lib/spi/spi_master.v     \
         ../rtl/lib/spi/lis3dh_stub.v
+SPIBB := 1
+ifdef SPIBB
+ICARUS += -DSPIBB=1
+RTLS += \
+        ../rtl/lib/spi/spi_master_bb.v
+endif
 endif
 
 INCS = ../rtl/config.vh

--- a/sim/darksimv.v
+++ b/sim/darksimv.v
@@ -66,9 +66,6 @@ module darksimv;
 
     wire TX;
     wire RX = 1;
-`ifdef SPI
-    wire SPI_MISO = 1'bz;
-`endif
 
 `ifdef __SDRAM__
 
@@ -87,18 +84,19 @@ module darksimv;
 
 `endif
 
-    darksocv soc0
+    darksocv
+`ifdef SPI
+    #(.SPI_DIV_COEF(1))
+`endif
+    soc0
     (
         .XCLK(CLK),
         .XRES(|RES),
-`ifdef __SDRAM__        
+`ifdef __SDRAM__
         .S_CLK(S_CLK),
         .S_NWE(S_NWE),
         .S_DQM(S_DQM),
         .S_DB (S_DB),
-`endif        
-`ifdef SPI
-        .SPI_MISO(SPI_MISO),
 `endif
         .UART_RXD(RX),
         .UART_TXD(TX)

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,6 +58,11 @@ endif
 ifeq ($(APPLICATION),spidemo)
     CFLAGS += -DSPI=1
     ASFLAGS += -DSPI=1
+SPIBB := 1
+ifdef SPIBB
+    CFLAGS += -DSPIBB=1
+    ASFLAGS += -DSPIBB=1
+endif
 endif
 
 DEPS = $(SRCS) $(ASMS) $(OBJS) $(PROJ).ld $(PROJ).lds $(LIBS) $(APPLICATION)/$(APPLICATION).a

--- a/src/darklibc/include/io.h
+++ b/src/darklibc/include/io.h
@@ -56,21 +56,9 @@ struct DARKIO {
 
     struct DARKSPI {
         union {
-            unsigned char      spi8;                   // 1c                                           r: {data}
-            unsigned short     spi16;                  // 1c/1d        w: {command,data}               r: {datalo,datahi}
-            unsigned int       spi32;                  // 1c/1d/1e/1f  w: {00,command,datalo,datahi}   r: {status,00,datalo,datahi}
-/*          struct {
-                unsigned char ignore0__[3];
-                unsigned char status;                  // 1f                                           r: {status}
-            };*/
-            struct {
-                unsigned char  ignore1__[2];
-                // This is hack to feed an SPI (simulation) stub with an expected value.
-                // It is voluntarily embedded/hidden within the regular SPI master address range.
-                // In order to write to it, we must generate special XBE=1100, which is ignored by SPI master ofc.
-                // It is then fed to the SPI stub within darkio itself.
-                unsigned short out_x_l_response;       // 1e/1f     ONLY FOR SIMULATION : LIS3DH stub out_x_l_response
-            };
+            unsigned char  spi8;  // 1c                              r: {data}
+            unsigned short spi16; // 1c/1d       w: {cmd,data}       r: {dlo,dhi}
+            unsigned int   spi32; // 1c/1d/1e/1f w: {00,cmd,dlo,dhi} r: {status,00,dlo,dhi}
         };
     } spi;
 

--- a/src/spidemo/Makefile
+++ b/src/spidemo/Makefile
@@ -44,6 +44,11 @@ DEPS = $(SRCS) $(ASMS) $(OBJS) $(LIBS) # $(PROJ).ld $(PROJ).lds $(DARKLIBC)/dark
 
 TARGETS = $(PROJ).a
 
+SPIBB := 1
+ifdef SPIBB
+CFLAGS += -DSPIBB=1
+endif
+
 .PHONY: all
 
 all: $(TARGETS) $(DEPS)

--- a/src/spidemo/main.c
+++ b/src/spidemo/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Marcelo Samsoniuk
+ * Copyright (c) 2025, Nicolas Sauzede <nicolas.sauzede@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,35 +33,81 @@
 #include <string.h>
 #include <math.h>
 
-unsigned short spi_transfer16(unsigned short command_data) {
+#ifdef SPIBB
+volatile int spibb_waste_counter = 0;
+static inline void spibb_waste_time(int n) {
+    for (int i = 0; i < n; i++) {
+        spibb_waste_counter++;
+    }
+}
+static inline int spibb_read_do_(void) {
+//    return 1 & (io->iport >> 31);
+    return !!(io->iport & (1 << 4));
+}
+volatile unsigned short g_spibb_out_x_resp = 0;
+static inline void spibb_write_oe_es_cl_di_(unsigned char oe_es_cl_di) {
+//    printf("%s: g_spibb_out_x_resp=%x\n", __func__, g_spibb_out_x_resp);
+    io->oport = ((unsigned int)g_spibb_out_x_resp << 16) | oe_es_cl_di;
+}
+unsigned int spibb_transfer_(unsigned int command_data, int nbits) {
+//    printf("%s: command_data=%x nbits=%d\n", __func__, command_data, nbits);
+    unsigned int ret = 0;
+    spibb_write_oe_es_cl_di_(0x7);    // output disabled / tristate       0111
+    spibb_write_oe_es_cl_di_(0xf);    // output enabled / SPI Idle        1111
+    spibb_write_oe_es_cl_di_(0xb);    // output enabled / SPI Active      1011
+    for (int i = nbits; i >= 0; i--) {
+        int bit;
+        bit = !!(command_data & (1 << i));
+        spibb_write_oe_es_cl_di_(0x8 | bit);                      //      100?
+        spibb_waste_time(3);
+        spibb_write_oe_es_cl_di_(0xa | bit);                      //      101?
+        bit = spibb_read_do_();
+        ret = (ret << 1) | bit;
+//        ret <<= 1;
+//        if (bit) ret++;
+    }
+    spibb_write_oe_es_cl_di_(0xf);    // output enabled / SPI Idle
+    spibb_write_oe_es_cl_di_(0x7);    // output disabled / tristate
+//    printf("%s: returning %x\n", __func__, ret);
+    return ret;
+}
+static inline unsigned short spibb_transfer16(unsigned short command_data) {
+    return spibb_transfer_(command_data, 15);
+}
+static inline unsigned int spibb_transfer24(unsigned int command_data) {
+    unsigned int spi16 = spibb_transfer_(command_data, 23);
+    return ((spi16 & 0xff) << 8) | ((spi16 & 0xff00) >> 8);
+}
+void bbset_stub_out_x_resp(unsigned short exp) {
+//    printf("%s: set exp=%x\n", __func__, exp);
+    g_spibb_out_x_resp = exp;
+}
+#endif
+void hwset_stub_out_x_resp(unsigned short exp) {
+//    printf("%s: set exp=%x\n", __func__, exp);
+    io->oport = ((unsigned int)exp << 16) | (io->oport & 0xffff);
+}
+unsigned short spihw_transfer16(unsigned short command_data) {
     unsigned short ret = -1;
     io->spi.spi16 = command_data;
     for (int i = 0; i < 1000000; i++) {
         int status = 0;
         status = *(volatile unsigned char *)((volatile char *)io + 0x1c + 3);
-//        if (status & 0x2000000) {
         if (status & 0x2) {
             ret = io->spi.spi8;
-//            ret = io->spi.spi16;
-//            ret = status & 0xffff;
             break;
         }
-//        printf("%s: status=%x\n", __func__, status);
     }
     return ret;
 }
 
-unsigned int spi_transfer24(unsigned int command_data) {
+unsigned int spihw_transfer24(unsigned int command_data) {
     unsigned int ret = -1;
     io->spi.spi32 = command_data & 0xffffff;
     for (int i = 0; i < 1000000; i++) {
         int status = 0;
-//        status = io->spi.spi32;
         status = *(volatile unsigned char *)((volatile char *)io + 0x1c + 3);
-//        if (status & 0x2000000) {
         if (status & 0x2) {
-//            ret = status & 0xffffff;
-//            ret = io->spi.spi16;
             unsigned short spi16 = io->spi.spi16;
             ret = ((spi16 & 0xff) << 8) | ((spi16 & 0xff00) >> 8);
             break;
@@ -70,15 +116,53 @@ unsigned int spi_transfer24(unsigned int command_data) {
     return ret;
 }
 
-int simu() {
-    io->led = 0xff;
+void (*set_stub_out_x_resp)(unsigned short exp) = hwset_stub_out_x_resp;
+unsigned short (*spi_transfer16)(unsigned short command_data) = spihw_transfer16;
+unsigned int (*spi_transfer24)(unsigned int command_data) = spihw_transfer24;
+#ifdef SPIBB
+int bb_active = 0;
+void set_bb(int active) {
+    bb_active = active;
+    if (active) {
+        bb_active = 1;
+        set_stub_out_x_resp = bbset_stub_out_x_resp;
+        spi_transfer16 = spibb_transfer16;
+        spi_transfer24 = spibb_transfer24;
+    } else {
+        bb_active = 0;
+        set_stub_out_x_resp = hwset_stub_out_x_resp;
+        spi_transfer16 = spihw_transfer16;
+        spi_transfer24 = spihw_transfer24;
+    }
+}
+#endif
+int whoami() {
     unsigned short ret = 0;
     unsigned short exp;
     exp = 0x33;
-    ret = spi_transfer16(0x8f00);
-    io->led = ret;
-    if ((ret & 0xff) != exp) {
-        printf("Bad Whoami %x expected %x\n>", ret, exp);
+//    printf("calling spi_transfer16\n");
+    ret = spi_transfer16(0x8f00) & 0xff;
+//    printf("spi_transfer16 returned %x\n", ret);
+#define HWTYPE "Whoami (HW)"
+#ifdef SPIBB
+#define BBTYPE "Whoami (BB)"
+    const char *type = bb_active ? BBTYPE : HWTYPE;
+#else
+    const char *type = HWTYPE;
+#endif
+    if (ret != exp) {
+        printf("Bad %s %x expected %x\n", type, ret, exp);
+        return 1;
+    } else {
+        printf("%s returned %x\n", type, ret);
+        return 0;
+    }
+}
+int sensor_init() {
+//    printf("setting led..\n");
+    io->led = 0xff;
+//    printf("calling whoami..\n");
+    if (whoami()) {
         return -1;
     }
     io->led = 0xfe;
@@ -87,11 +171,25 @@ int simu() {
     spi_transfer16(0x1fc0);
     io->led = 0xfb;
     spi_transfer16(0x2388);
+    return 0;
+}
+unsigned short sensor_read() {
+    unsigned short ret = spi_transfer24(0xe80000);
+    return ret;
+}
+int simu() {
+//    printf("init sensor..\n");
+    if (sensor_init()) {
+        printf("init failed ??\n");
+        return -1;
+    }
+    unsigned short ret = 0;
+    unsigned short exp;
     exp = 0x9a00;
-    for (int i = 0; i < 1000000; i++) {
+    for (int i = 0; i <= 16; i++) {
         //printf("i=%d\n", i);
-        io->spi.out_x_l_response = exp;
-        ret = spi_transfer24(0xe80000);
+        set_stub_out_x_resp(exp);
+        ret = sensor_read();
         if (ret != exp) {
             printf("Bad out_x %x expected %x\n>", ret, exp);
             return -1;
@@ -99,36 +197,24 @@ int simu() {
         unsigned char led_out = 1 << (((ret & 0xff00) >> 8) >> 5);
         io->led = led_out;
         exp += 0x2000;
-        if (i == 16)
-            printf("Test passed.\n>");
     }
+    printf("Test passed.\n");  // The ">" ends the simulation early
     return 0;
 }
 int sensor() {
-    io->led = 0xff;
-    unsigned short ret = 0;
-    unsigned short exp;
-    exp = 0x33;
-    ret = spi_transfer16(0x8f00);
-    io->led = ret;
-    if ((ret & 0xff) != exp) {
-        printf("Bad Whoami %x expected %x\n>", ret, exp);
+    if (sensor_init()) {
         return -1;
     }
-    io->led = 0xfe;
-    spi_transfer16(0x2077);
-    io->led = 0xfd;
-    spi_transfer16(0x1fc0);
-    io->led = 0xfb;
-    spi_transfer16(0x2388);
     printf("Reading OUT_X.. (press a key to stop)\n");
+    unsigned char accmin = 0, accmax = 0;
+    unsigned char oldval = -1;
     while (1) {
         if (io->uart.stat&2) {
             break;
         }
-        ret = spi_transfer24(0xe80000);
+        unsigned short ret = 0;
+        ret = sensor_read();
         unsigned char acc = ((ret & 0xff00) >> 8) + 0x20 * 4;
-        static unsigned char accmin = 0, accmax = 0;
         if (!accmin && !accmax) {
             accmin = acc;
             accmax = acc;
@@ -144,7 +230,6 @@ int sensor() {
         if (!range) range++;
         unsigned char val = (int)(acc - accmin) * 8 / range;
         if (val > 7) val = 7;
-        static unsigned char oldval = -1;
         if (oldval != val) {
             printf("out_x=%x acc=%x min=%x max=%x val=%x\n", ret, acc, accmin, accmax, val);
         }
@@ -154,25 +239,16 @@ int sensor() {
     }
     return 0;
 }
-int whoami() {
-    io->led = 0x55;
-    unsigned short ret = 0;
-    unsigned short exp;
-    exp = 0x33;
-    ret = spi_transfer16(0x8f00);
-    io->led = ret;
-    if ((ret & 0xff) != exp) {
-        printf("Bad Whoami %x expected %x\n", ret, exp);
-        return 1;
-    } else {
-        printf("Whoami returned %x\n", ret);
-        return 0;
-    }
-}
 int main(void)
 {
     if (!io->board_id) {
-        return simu();
+//        printf("running simu..\n");
+        simu();
+#ifdef SPIBB
+        set_bb(1);
+        simu();
+#endif
+        printf(">");  // The ">" ends the simulation early
     }
 
     unsigned t=0,t0=0;
@@ -189,13 +265,30 @@ int main(void)
         printf("%d> ",t-t0);
         gets(buffer,sizeof(buffer));
         printf("You entered [%s]\n", buffer);
-        if (!strncmp("whoami", buffer, 6)) {
+        if (!strcmp("whoami", buffer)) {
             whoami();
-        } else if (!strncmp("led", buffer, 3)) {
+        } else if (!strcmp("led", buffer)) {
             printf("led was %x\n", io->led);
             io->led = ~io->led;
-        } else if (!strncmp("sensor", buffer, 6)) {
+        } else if (!strcmp("simu", buffer)) {
+            simu();
+        } else if (!strcmp("sensor", buffer)) {
             sensor();
+        } else if(!strcmp("iport", buffer)) {
+              printf("iport = %x\n",io->iport);
+        } else if(!strcmp("oport", buffer)) {
+              printf("oport = %x\n",io->oport);
+        } else if (!strcmp("read", buffer)) {
+            unsigned short ret = sensor_read();
+            printf("%s: ret=%x\n", __func__, ret);
+#ifdef SPIBB
+        } else if (!strncmp("set_bb ", buffer, 7)) {
+            if (buffer[7]) {
+                int active = atoi(buffer+7);
+                printf("%s: set bb active=%x\n", __func__, active);
+                set_bb(active);
+            }
+#endif
         } else if(!strcmp(buffer,"reboot")) {
             printf("rebooting...\n");
             break;


### PR DESCRIPTION
This PR mostly cleans up the existing SPI support, moving things to where they belong better and, remove obsolete things.
It also introduces an experimental bitbanging SPI master, confirmed to work independently from the darkspi HW IP.
A similar approach could then be used to introduce I2C support in future work.

- [x] Fix lis3dh_stub SPI stub timing
- [x] Fix spi_master div coef for sim/synth
- [x] Spread inout ports for SPI
- [x] Add alternative SPI bitbanging (SPIBB)
- [x] Move SPI sensor stub from darkio to darksocv
- [x] Eliminate out_x_resp from darkio & io.h