### PR TITLE
Bug Fix: correcting immediate encoding for unsigned instructions

### DIFF
--- a/rtl/darkriscv.v
+++ b/rtl/darkriscv.v
@@ -481,7 +481,7 @@ module darkriscv
     // RM-group of instructions (OPCODEs==7'b0010011/7'b0110011), merged! src=immediate(M)/register(R)
 
     wire signed [31:0] S2REGX = XMCC ? SIMM : S2REG;
-    wire        [31:0] U2REGX = XMCC ? UIMM : U2REG;
+    wire        [31:0] U2REGX = XMCC ? SIMM : U2REG;
 
     wire [31:0] RMDATA = FCT3==7 ? U1REG&S2REGX :
                          FCT3==6 ? U1REG|S2REGX :


### PR DESCRIPTION
# Bug fix
First of all, congratulations for your work in the darkriscv core! It is a very popular processor. I'm working on a project that involves RISC-V processors verification, and I used darkriscv in my evaluation.
[Our Project](https://processorci.lsc.ic.unicamp.br/)

## The Issue
Darkriscv is failing to execute the SLTIU instruction when the immediate is negative. The darkriscv source code uses an "unsigned immediate" to perform the SLTIU comparison, which is the immediate bits extended with zeroes.

https://github.com/darklife/darkriscv/blob/61bd172f9aa24564ad7c3b98dd8bb33546bb0ed6/rtl/darkriscv.v#L195-L201

However, according to the RISC-V manual v20250508, page 25, all immediate must be sign-extended, even if later evaluated as unsigned.

<img width="848" height="133" alt="Captura de tela 2026-01-06 141534" src="https://github.com/user-attachments/assets/0a80af18-2b68-424d-9db9-81940985f3c3" />

The only instructions that use this kind of unsigned immediate are CSR instructions that I believe were not implemented in darkriscv. This was extracted from the same manual, page 49.

<img width="859" height="310" alt="Captura de tela 2026-01-06 141512" src="https://github.com/user-attachments/assets/bd5588bc-a2aa-4178-904a-625b02da9d62" />

## How to Reproduce
 This code snippet from the [riscv-arch-test](https://github.com/riscv-non-isa/riscv-arch-test) suite is enough to reproduce the error:
```
800002c4 <inst_21>:
800002c4:	40000eb7          	lui	t4,0x40000
800002c8:	ff7eb893          	sltiu	a7,t4,-9
800002cc:	01112623          	sw	a7,12(sp)
```

## The Fix
Since all immediates must be sign-extended, I removed the unsigned immediates.